### PR TITLE
[DEVOPS-863] Добавление канала для IBM MQ (autotester), настройки - и…

### DIFF
--- a/atf-application/src/main/java/ru/bsc/test/autotester/mapper/ProjectRoMapper.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/mapper/ProjectRoMapper.java
@@ -112,7 +112,9 @@ public abstract class ProjectRoMapper {
             @Mapping(target = "port", source = "port"),
             @Mapping(target = "username", source = "username"),
             @Mapping(target = "password", source = "password"),
-
+            @Mapping(target = "channel", source = "channel"),
+            @Mapping(target = "maxTimeoutWait", source = "maxTimeoutWait"),
+            @Mapping(target = "useCamelNamingPolicyIbmMQ", source = "useCamelNamingPolicyIbmMQ")
     })
     public abstract AmqpBroker updateAmqpBrokerFromRo(AmqpBrokerRo amqpBrokerRo);
 

--- a/atf-application/src/main/java/ru/bsc/test/autotester/properties/AmqpBrokerProperties.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/properties/AmqpBrokerProperties.java
@@ -31,4 +31,8 @@ public class AmqpBrokerProperties {
     private Integer port;
     private String password;
     private String username;
+    private String channel;
+    private long maxTimeoutWait;
+    private Boolean useCamelNamingPolicyIbmMQ;
+
 }

--- a/atf-application/src/main/java/ru/bsc/test/autotester/repository/yaml/YamlProjectRepositoryImpl.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/repository/yaml/YamlProjectRepositoryImpl.java
@@ -227,6 +227,9 @@ public class YamlProjectRepositoryImpl extends BaseYamlRepository implements Pro
                 amqpBroker.setPort(standProperties.getAmqpBroker().getPort());
                 amqpBroker.setUsername(standProperties.getAmqpBroker().getUsername());
                 amqpBroker.setPassword(standProperties.getAmqpBroker().getPassword());
+                amqpBroker.setChannel(standProperties.getAmqpBroker().getChannel());
+                amqpBroker.setMaxTimeoutWait(standProperties.getAmqpBroker().getMaxTimeoutWait());
+                amqpBroker.setUseCamelNamingPolicyIbmMQ(standProperties.getAmqpBroker().getUseCamelNamingPolicyIbmMQ());
                 project.setAmqpBroker(amqpBroker);
             }
         }

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/AmqpBrokerRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/AmqpBrokerRo.java
@@ -31,4 +31,7 @@ public class AmqpBrokerRo implements AbstractRo {
     private Integer port;
     private String username;
     private String password;
+    private String channel;
+    private long maxTimeoutWait;
+    private Boolean useCamelNamingPolicyIbmMQ;
 }

--- a/atf-application/src/main/resources/api/api.yaml
+++ b/atf-application/src/main/resources/api/api.yaml
@@ -535,6 +535,13 @@ definitions:
         type: string
       password:
         type: string
+      channel:
+        type: string
+      maxTimeoutWait:
+        type: integer
+        format: int64
+      useCamelNamingPolicyIbmMQ:
+        type: boolean
   Scenario:
     type: object
     properties:

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/MqMockHelper.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/MqMockHelper.java
@@ -43,6 +43,18 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class MqMockHelper {
+    private static final String HYPHEN = "_HYPHEN_";
+    private static final String DOT = "_DOT_";
+
+
+
+    public static String convertPropertyCamelPolicy(String testIdHeaderNameProperty, boolean useCamelNamingPolicy) {
+        if(useCamelNamingPolicy && testIdHeaderNameProperty != null && !testIdHeaderNameProperty.isEmpty()) {
+            testIdHeaderNameProperty = testIdHeaderNameProperty.replace("-", HYPHEN)
+                    .replace(".", DOT);
+        }
+        return testIdHeaderNameProperty;
+    }
 
     public void assertMqRequests(WireMockAdmin mqMockerAdmin, String testId, Step step, Map<String, Object> scenarioVariables, Integer mqCheckCount, Long mqCheckInterval) throws Exception {
         if (mqMockerAdmin == null) {
@@ -138,4 +150,5 @@ public class MqMockHelper {
             throw new ComparisonException(diff, expectedRequest, actualRequest);
         }
     }
+
 }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/model/AmqpBroker.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/model/AmqpBroker.java
@@ -34,6 +34,9 @@ public class AmqpBroker implements AbstractModel, Serializable {
     private Integer port;
     private String username;
     private String password;
+    private String channel;
+    private long maxTimeoutWait;
+    private Boolean useCamelNamingPolicyIbmMQ;
 
     public AmqpBroker copy() {
         AmqpBroker copy = new AmqpBroker();
@@ -42,6 +45,10 @@ public class AmqpBroker implements AbstractModel, Serializable {
         copy.setPort(getPort());
         copy.setUsername(getUsername());
         copy.setPassword(getPassword());
+        copy.setChannel(getChannel());
+        copy.setMaxTimeoutWait(getMaxTimeoutWait());
+        copy.setUseCamelNamingPolicyIbmMQ(getUseCamelNamingPolicyIbmMQ());
         return copy;
     }
+
 }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/IbmMqManager.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/IbmMqManager.java
@@ -19,7 +19,9 @@
 package ru.bsc.test.at.executor.mq;
 
 import com.ibm.mq.jms.MQQueueConnectionFactory;
+import com.ibm.msg.client.wmq.WMQConstants;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.jms.Connection;
 import javax.jms.JMSException;
@@ -30,11 +32,16 @@ public class IbmMqManager extends AbstractMqManager {
 
     private QueueConnection connection;
 
-    IbmMqManager(String host, int port, String username, String password) throws JMSException {
+    IbmMqManager(String host, int port, String username, String password, String channel) throws JMSException {
         MQQueueConnectionFactory connectionFactory = new MQQueueConnectionFactory();
         connectionFactory.setHostName(host);
         connectionFactory.setPort(port);
-        connectionFactory.setTransportType(1);
+        connectionFactory.setTransportType(WMQConstants.WMQ_CM_CLIENT);
+
+        if(channel != null && !channel.isEmpty()) {
+            connectionFactory.setChannel(channel);
+        }
+
         connection = (QueueConnection) connectionFactory.createConnection(username, password);
         connection.start();
     }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/MqManagerFactory.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/MqManagerFactory.java
@@ -24,13 +24,13 @@ public final class MqManagerFactory {
 
     private MqManagerFactory() { }
 
-    public static AbstractMqManager getMqManager(MqService mqService, String host, Integer port, String username, String password) throws JMSException, ReflectiveOperationException {
+    public static AbstractMqManager getMqManager(MqService mqService, String host, Integer port, String username, String password, String channel) throws JMSException, ReflectiveOperationException {
         if (MqService.ACTIVE_MQ.equals(mqService)) {
             return new ActiveMqManager(host, port, username, password);
         } else if (MqService.RABBIT_MQ.equals(mqService)) {
             return new RabbitMqManager(host, port, username, password);
         } else if(MqService.IBM_MQ.equals(mqService)) {
-            return new IbmMqManager(host, port, username, password);
+            return new IbmMqManager(host, port, username, password, channel);
         } else {
             throw new UnsupportedOperationException("MqService " + mqService + " is not supported");
         }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/step/executor/AbstractStepExecutor.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/step/executor/AbstractStepExecutor.java
@@ -31,6 +31,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import ru.bsc.test.at.executor.ei.wiremock.WireMockAdmin;
 import ru.bsc.test.at.executor.ei.wiremock.model.*;
+import ru.bsc.test.at.executor.helper.MqMockHelper;
 import ru.bsc.test.at.executor.helper.NamedParameterStatement;
 import ru.bsc.test.at.executor.helper.client.api.ClientResponse;
 import ru.bsc.test.at.executor.helper.client.impl.mq.ClientMQRequest;
@@ -92,6 +93,7 @@ public abstract class AbstractStepExecutor implements IStepExecutor {
                     log.error("Error while evaluate expression", e);
                 }
             });
+            testIdHeaderName = MqMockHelper.convertPropertyCamelPolicy(testIdHeaderName, mqClient.isUseCamelNamingPolicyIbmMQ());
             ClientMQRequest clientMQRequest = new ClientMQRequest(message.getQueueName(), messageText, generatedProperties, testId, testIdHeaderName);
             mqClient.request(clientMQRequest);
         }


### PR DESCRIPTION
Произведенные работы: добавлено 3 новые настройки

      amqpBroker:
        host: 192.168.99.100
        mqService: IBM_MQ
        password: password
        port: 1414
        username: app
        channel: DEV.APP.SVRCONN
       maxTimeoutWait: 60000000
       useCamelNamingPolicyIbmMQ: true

- channel  - необходима для отправки/получения сообщения при помощи MQ с вкладки Details для WebSphere MQ (иначе возникает проблема с безопасностью)
- maxTimeoutWait - максимальное время ожидания до этого было ограничено 1 минутой, по умолчианию 1 минута и остается, но в случае необходимости можно задать большее время ожиданя сообщения (определяется как min{Timeout на Details, maxTimeoutWait}
-  useCamelNamingPolicyIbmMQ - IBM_MQ требует, чтобы свойства для JMS сообщений соответствовали правилам наименования бинов. Поэтому было решено добавить возможность, аналогичную возможности в camel - конвертация ./- в символьные константы. Это позволяет обойти ряд проблем с IBM_MQ
- Исправлена проблема - при отправке с вкладки Details не передавалась очередь ответов (проблема воспроизводится для IBM_MQ, но логически актуальна и для Rabbit MQ)