### PR TITLE
Fb devops 863

### DIFF
--- a/atf-application/src/main/java/ru/bsc/test/autotester/mapper/ProjectRoMapper.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/mapper/ProjectRoMapper.java
@@ -112,7 +112,9 @@ public abstract class ProjectRoMapper {
             @Mapping(target = "port", source = "port"),
             @Mapping(target = "username", source = "username"),
             @Mapping(target = "password", source = "password"),
-
+            @Mapping(target = "channel", source = "channel"),
+            @Mapping(target = "maxTimeoutWait", source = "maxTimeoutWait"),
+            @Mapping(target = "useCamelNamingPolicyIbmMQ", source = "useCamelNamingPolicyIbmMQ")
     })
     public abstract AmqpBroker updateAmqpBrokerFromRo(AmqpBrokerRo amqpBrokerRo);
 

--- a/atf-application/src/main/java/ru/bsc/test/autotester/properties/AmqpBrokerProperties.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/properties/AmqpBrokerProperties.java
@@ -31,4 +31,8 @@ public class AmqpBrokerProperties {
     private Integer port;
     private String password;
     private String username;
+    private String channel;
+    private long maxTimeoutWait;
+    private boolean useCamelNamingPolicyIbmMQ;
+
 }

--- a/atf-application/src/main/java/ru/bsc/test/autotester/repository/yaml/YamlProjectRepositoryImpl.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/repository/yaml/YamlProjectRepositoryImpl.java
@@ -227,6 +227,10 @@ public class YamlProjectRepositoryImpl extends BaseYamlRepository implements Pro
                 amqpBroker.setPort(standProperties.getAmqpBroker().getPort());
                 amqpBroker.setUsername(standProperties.getAmqpBroker().getUsername());
                 amqpBroker.setPassword(standProperties.getAmqpBroker().getPassword());
+                amqpBroker.setChannel(standProperties.getAmqpBroker().getChannel());
+                amqpBroker.setMaxTimeoutWait(standProperties.getAmqpBroker().getMaxTimeoutWait());
+                amqpBroker.setUseCamelNamingPolicyIbmMQ(standProperties.getAmqpBroker().isUseCamelNamingPolicyIbmMQ());
+
                 project.setAmqpBroker(amqpBroker);
             }
         }

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/AmqpBrokerRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/AmqpBrokerRo.java
@@ -39,4 +39,10 @@ public class AmqpBrokerRo implements AbstractRo {
     private String username;
     @ApiModelProperty("MQ server password")
     private String password;
+    @ApiModelProperty("MQ server channel")
+    private String channel;
+    @ApiModelProperty("The timeout value (in milliseconds), a time out of zero never expires.")
+    private long maxTimeoutWait;
+    @ApiModelProperty("Use camel naming policy for MQ properties.")
+    private boolean useCamelNamingPolicyIbmMQ;
 }

--- a/atf-application/src/main/resources/api/api.yaml
+++ b/atf-application/src/main/resources/api/api.yaml
@@ -535,6 +535,13 @@ definitions:
         type: string
       password:
         type: string
+      channel:
+        type: string
+      maxTimeoutWait:
+        type: integer
+        format: int64
+      useCamelNamingPolicyIbmMQ:
+        type: boolean
   Scenario:
     type: object
     properties:

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/MqMockHelper.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/MqMockHelper.java
@@ -19,6 +19,7 @@
 package ru.bsc.test.at.executor.helper;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
 import ru.bsc.test.at.executor.ei.wiremock.WireMockAdmin;
@@ -35,6 +36,16 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class MqMockHelper {
+
+    private static final String HYPHEN = "_HYPHEN_";
+    private static final String DOT = "_DOT_";
+
+
+    public static String convertPropertyCamelPolicy(String testIdHeaderNameProperty, boolean useCamelNaming) {
+        return useCamelNaming && !StringUtils.isEmpty(testIdHeaderNameProperty) ?
+                testIdHeaderNameProperty.replace("-", HYPHEN).replace(".", DOT) : testIdHeaderNameProperty;
+    }
+
 
     public void assertMqRequests(WireMockAdmin mqMockerAdmin, String testId, Step step, Map<String, Object> scenarioVariables, Integer mqCheckCount, Long mqCheckInterval) throws Exception {
         if (mqMockerAdmin == null) {

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/model/AmqpBroker.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/model/AmqpBroker.java
@@ -34,6 +34,9 @@ public class AmqpBroker implements AbstractModel, Serializable {
     private Integer port;
     private String username;
     private String password;
+    private String channel;
+    private long maxTimeoutWait;
+    private boolean useCamelNamingPolicyIbmMQ;
 
     public AmqpBroker copy() {
         AmqpBroker copy = new AmqpBroker();
@@ -42,6 +45,9 @@ public class AmqpBroker implements AbstractModel, Serializable {
         copy.setPort(getPort());
         copy.setUsername(getUsername());
         copy.setPassword(getPassword());
+        copy.setChannel(getChannel());
+        copy.setMaxTimeoutWait(getMaxTimeoutWait());
+        copy.setUseCamelNamingPolicyIbmMQ(isUseCamelNamingPolicyIbmMQ());
         return copy;
     }
 }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/IbmMqManager.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/IbmMqManager.java
@@ -19,6 +19,7 @@
 package ru.bsc.test.at.executor.mq;
 
 import com.ibm.mq.jms.MQQueueConnectionFactory;
+import com.ibm.msg.client.wmq.WMQConstants;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.jms.Connection;
@@ -30,11 +31,16 @@ public class IbmMqManager extends AbstractMqManager {
 
     private QueueConnection connection;
 
-    IbmMqManager(String host, int port, String username, String password) throws JMSException {
+    IbmMqManager(String host, int port, String username, String password, String channel) throws JMSException {
         MQQueueConnectionFactory connectionFactory = new MQQueueConnectionFactory();
         connectionFactory.setHostName(host);
         connectionFactory.setPort(port);
-        connectionFactory.setTransportType(1);
+        connectionFactory.setTransportType(WMQConstants.WMQ_CM_CLIENT);
+
+        if(channel != null && !channel.isEmpty()) {
+            connectionFactory.setChannel(channel);
+        }
+
         connection = (QueueConnection) connectionFactory.createConnection(username, password);
         connection.start();
     }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/MqManagerFactory.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/mq/MqManagerFactory.java
@@ -24,13 +24,13 @@ public final class MqManagerFactory {
 
     private MqManagerFactory() { }
 
-    public static AbstractMqManager getMqManager(MqService mqService, String host, Integer port, String username, String password) throws JMSException, ReflectiveOperationException {
+    public static AbstractMqManager getMqManager(MqService mqService, String host, Integer port, String username, String password, String channel) throws JMSException, ReflectiveOperationException {
         if (MqService.ACTIVE_MQ.equals(mqService)) {
             return new ActiveMqManager(host, port, username, password);
         } else if (MqService.RABBIT_MQ.equals(mqService)) {
             return new RabbitMqManager(host, port, username, password);
         } else if(MqService.IBM_MQ.equals(mqService)) {
-            return new IbmMqManager(host, port, username, password);
+            return new IbmMqManager(host, port, username, password, channel);
         } else {
             throw new UnsupportedOperationException("MqService " + mqService + " is not supported");
         }

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/application/MockApplication.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/application/MockApplication.java
@@ -24,6 +24,8 @@ import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.jetty9.DefaultMultipartRequestConfigurer;
+import com.github.tomakehurst.wiremock.servlet.MultipartRequestConfigurer;
 import com.github.tomakehurst.wiremock.servlet.NotImplementedContainer;
 import com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,8 +100,13 @@ public class MockApplication {
         context.setAttribute(StubRequestHandler.class.getName(), wireMockApp.buildStubRequestHandler());
         context.setAttribute(AdminRequestHandler.class.getName(), wireMockApp.buildAdminRequestHandler());
         context.setAttribute(Notifier.KEY, new Slf4jNotifier(false));
+        context.setAttribute(MultipartRequestConfigurer.KEY, buildMultipartRequestConfigurer());
 
         return wireMockApp;
+    }
+
+    protected MultipartRequestConfigurer buildMultipartRequestConfigurer() {
+        return new DefaultMultipartRequestConfigurer();
     }
 
     @Bean


### PR DESCRIPTION
Внес правки согласно комментариям и разрешил конфликты.

`      

- channel: DEV.APP.SVRCONN<br>
- maxTimeoutWait: 60000<br> 
- useCamelNamingPolicyIbmMQ: true`

Цель доработки была позволить вообще отправлять сообщения с вкладки Детали в IBM MQ и при этом указывать очередь ответов.

После поднятия версии wiremock server'a, мы обнаружили проблему (WPS-11190) при работе с мультипартом происходит NPE, т.к. отсутствует конфигурация, которую теперь выполняет jetty.

Имеется так же просьба
1) Добавить maven-pmd-plugin, findbugs-maven-plugin, maven-checkstyle-plugin и настроить список правил. И нам и вам будет удобнее писать и проверять.
2) Переносить коммиты из внутренних репозиториев в публичный при помощи patсhes. 
В итоге, большая часть коммитов имеет комментарий - "Перенос из внутренннего репозитория". Имеем один коммит с кучей измененных файлов - тяжело разбираться в изменениях. Чистота в коммитах позволит лучше ориентироваться в изменениях
