### PR TITLE
Fb devops 1178 1184

### DIFF
--- a/atf-application-ui/src/app/mock-service-response/mock-service-response.component.html
+++ b/atf-application-ui/src/app/mock-service-response/mock-service-response.component.html
@@ -64,6 +64,7 @@
         <option [ngValue]="'XPath'">XPath</option>
         <option [ngValue]="'contains'">contains</option>
         <option [ngValue]="'matches'">matches</option>
+        <option [ngValue]="'absent'">absent</option>
       </select>
     </div>
     <div class="col-sm-3" style="margin-top: 10px">

--- a/atf-application-ui/src/app/step-item/step-item.component.html
+++ b/atf-application-ui/src/app/step-item/step-item.component.html
@@ -479,6 +479,7 @@
                         <option [ngValue]="'XPath'">XPath</option>
                         <option [ngValue]="'contains'">contains</option>
                         <option [ngValue]="'matches'">matches</option>
+                        <option [ngValue]="'absent'">absent</option>
                       </select>
                     </div>
 

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/ExpectedServiceRequestRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/ExpectedServiceRequestRo.java
@@ -48,7 +48,7 @@ public class ExpectedServiceRequestRo implements AbstractRo {
     private String ignoredTags;
     @ApiModelProperty("Count of request repetitions")
     private String count;
-    @ApiModelProperty(value = "Type of matching request", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches")
+    @ApiModelProperty(value = "Type of matching request", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches, absent")
     private String typeMatching;
     @ApiModelProperty("Value which will be used to match request. Depends on typeMatching")
     private String pathFilter;

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/MockServiceResponseRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/MockServiceResponseRo.java
@@ -54,7 +54,7 @@ public class MockServiceResponseRo implements AbstractRo {
     private String userName;
     @ApiModelProperty("Password for using basic authentication")
     private String password;
-    @ApiModelProperty(value = "Type of matching response", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches")
+    @ApiModelProperty(value = "Type of matching response", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches, absent")
     private String typeMatching;
     @ApiModelProperty("Value which will be used to match response. Depends on typeMatching")
     private String pathFilter;

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/ei/wiremock/model/RequestMatcher.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/ei/wiremock/model/RequestMatcher.java
@@ -41,10 +41,12 @@ public class RequestMatcher {
     public static final String XPATH = "XPath";
     public static final String CONTAINS = "contains";
     public static final String MATCHES = "matches";
+    public static final String ABSENT = "absent";
 
     private String equalToJson;
     private String equalToXml;
     private String matchesXPath;
+    private String absent;
     @JsonRawValue
     private String contains;
     @JsonRawValue
@@ -63,6 +65,8 @@ public class RequestMatcher {
             newRequestMatcher.setMatchesXPath(value);
         } else if (MATCHES.equalsIgnoreCase(type)) {
             newRequestMatcher.setMatches(StringUtils.wrap(value, "\""));
+        } else if (ABSENT.equalsIgnoreCase(type)){
+            newRequestMatcher.setAbsent("absent_pattern");
         }
         return newRequestMatcher;
     }
@@ -71,6 +75,6 @@ public class RequestMatcher {
     public boolean isPresent() {
         return isNotEmpty(equalToJson) || isNotEmpty(equalToXml) ||
                 isNotEmpty(matchesXPath) || isNotEmpty(contains) ||
-                isNotEmpty(matches);
+                isNotEmpty(matches) || isNotEmpty(absent);
     }
 }

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/step/executor/MqStepExecutor.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/step/executor/MqStepExecutor.java
@@ -43,6 +43,9 @@ public class MqStepExecutor implements IStepExecutor {
         // 0. Установить ответы сервисов, которые будут использоваться в SoapUI для определения ответа
         ExecutorUtils.setMockResponses(wireMockAdmin, project, testId, step.getMockServiceResponseList(), scenarioVariables);
 
+        // 0.1 Установить ответы для имитации внешних сервисов, работающих через очереди сообщений
+        ExecutorUtils.setMqMockResponses(wireMockAdmin, testId, step.getMqMockResponseList(), scenarioVariables);
+
         // 1. Выполнить запрос БД и сохранить полученные значения
         ExecutorUtils.executeSql(connection, step, scenarioVariables, stepResult);
         stepResult.setSavedParameters(scenarioVariables.toString());

--- a/atf-wiremock/pom.xml
+++ b/atf-wiremock/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.22.0</version>
+            <version>2.24.1</version>
         </dependency>
 
         <dependency>

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/mq/AbstractMqWorker.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/mq/AbstractMqWorker.java
@@ -19,15 +19,13 @@
 package ru.bsc.test.at.mock.mq.mq;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import ru.bsc.test.at.mock.mq.models.MockMessage;
 
-import javax.jms.ExceptionListener;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-import javax.jms.TextMessage;
+import javax.jms.*;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -132,12 +130,13 @@ abstract public class AbstractMqWorker implements Runnable, ExceptionListener {
     }
 
     void copyMessageProperties(
-            TextMessage message,
-            TextMessage newMessage,
+            Message message,
+            Message newMessage,
             String testId,
             Queue destination
     ) throws JMSException {
-        newMessage.setJMSCorrelationID(message.getJMSMessageID());
+        String jmsCorrelationId = message.getJMSCorrelationID();
+        newMessage.setJMSCorrelationID(StringUtils.isNotEmpty(jmsCorrelationId) ? jmsCorrelationId : message.getJMSMessageID());
 
         newMessage.setStringProperty(testIdHeaderName, testId);
         newMessage.setJMSDestination(destination);

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/mq/IbmMQWorker.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/mq/IbmMQWorker.java
@@ -80,25 +80,38 @@ public class IbmMQWorker extends AbstractMqWorker {
                     log.info("Wait messages from {}", queueNameFrom);
                     Message receivedMessage = consumer.receive();
                     String jmsMessageId = receivedMessage.getJMSMessageID();
-                    String jmsReplyTo = receivedMessage.getJMSReplyTo().toString();
+                    String jmsCorrelationId = receivedMessage.getJMSCorrelationID();
+                    String jmsReplyTo = receivedMessage.getJMSReplyTo() == null ? null : receivedMessage.getJMSReplyTo().toString();
 
-                    log.info("Received message: JMSMessageID={}, JMSReplyTo={}", jmsMessageId, jmsReplyTo);
+                    log.info("Received message: JMSMessageID={}, JMSReplyTo={}, JmsCorrelationID={}", jmsMessageId, jmsReplyTo, jmsCorrelationId);
+                    log.info("Received message: {}", receivedMessage);
 
                     MockedRequest mockedRequest = new MockedRequest();
                     //noinspection unchecked
                     fifo.add(mockedRequest);
                     mockedRequest.setSourceQueue(queueNameFrom);
 
-                    if (!(receivedMessage instanceof TextMessage)) {
-                        mockedRequest.setRequestBody("<not text message>");
+                    String stringBody;
+                    if (receivedMessage instanceof TextMessage) {
+                        TextMessage message = (TextMessage) receivedMessage;
+                        stringBody = message.getText();
+                    } else if (receivedMessage instanceof BytesMessage) {
+                        BytesMessage byteMessage = (BytesMessage) receivedMessage;
+                        byte[] byteData = new byte[(int) byteMessage.getBodyLength()];
+                        byteMessage.readBytes(byteData);
+                        stringBody = new String(byteData).replaceAll("<\\?xml(.+?)\\?>", "").trim();
+                    } else {
+                        mockedRequest.setRequestBody("<not text or byte message>");
                         continue;
                     }
-                    TextMessage message = (TextMessage) receivedMessage;
-                    String stringBody = message.getText();
                     mockedRequest.setRequestBody(stringBody);
                     log.info(" [x] Received <<< {} {}", queueNameFrom, stringBody);
 
-                    String testId = message.getStringProperty(testIdHeaderName);
+                    String testId = receivedMessage.getStringProperty(testIdHeaderName);
+                    if (StringUtils.isEmpty(testId)) {
+                        testIdHeaderName = convertTestIdHeaderName();
+                        testId = receivedMessage.getStringProperty(testIdHeaderName);
+                    }
                     mockedRequest.setTestId(testId);
 
                     MockMessage mockMessage = findMockMessage(testId, stringBody);
@@ -114,7 +127,7 @@ public class IbmMQWorker extends AbstractMqWorker {
                                 response = new VelocityTransformer().transform(stringBody, null, mockResponse.getResponseBody()).getBytes();
                             } else if (StringUtils.isNotEmpty(mockMessage.getHttpUrl())) {
                                 try (HttpClient httpClient = new HttpClient()) {
-                                    response = httpClient.sendPost(mockMessage.getHttpUrl(), message.getText(), testIdHeaderName, testId).getBytes();
+                                    response = httpClient.sendPost(mockMessage.getHttpUrl(), stringBody, testIdHeaderName, testId).getBytes();
                                 }
                                 mockedRequest.setHttpRequestUrl(mockMessage.getHttpUrl());
                             } else {
@@ -125,45 +138,11 @@ public class IbmMQWorker extends AbstractMqWorker {
                                                       ? mockResponse.getDestinationQueueName()
                                                       : jmsReplyTo;
 
-                            mockedRequest.setDestinationQueue(destinationQueue);
-
-                            if (isNotEmpty(destinationQueue)) {
-
-                                mockedRequest.setResponseBody(new String(response, StandardCharsets.UTF_8));
-
-                                Queue destination = session.createQueue(destinationQueue);
-                                MessageProducer producer = session.createProducer(destination);
-                                producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
-
-                                TextMessage newMessage = session.createTextMessage(new String(response, StandardCharsets.UTF_8));
-                                copyMessageProperties(message, newMessage, testId, destination);
-
-                                // Переслать сообщение в очередь-назначение
-                                producer.send(newMessage);
-
-                                producer.close();
-                                log.info(" [x] Send >>> {} '{}'", destinationQueue, message.getText(), StandardCharsets.UTF_8);
-                            }
+                            sendMessage(session, receivedMessage, mockedRequest, destinationQueue, new String(response, StandardCharsets.UTF_8), testId, DeliveryMode.NON_PERSISTENT);
                         }
                     } else {
                         // Переслать сообщение в очередь "по-умолчанию".
-                        mockedRequest.setDestinationQueue(queueNameTo);
-                        if (isNotEmpty(queueNameTo)) {
-                            mockedRequest.setResponseBody(stringBody);
-
-                            Queue destination = session.createQueue(queueNameTo);
-                            MessageProducer producer = session.createProducer(destination);
-                            TextMessage newMessage = session.createTextMessage(message.getText());
-
-                            copyMessageProperties(message, newMessage, testId, destination);
-
-                            // Переслать сообщение в очередь-назначение
-                            producer.send(newMessage);
-                            producer.close();
-                            log.info(" [x] Send >>> {} '{}'", queueNameTo, message.getText(), "UTF-8");
-                        } else {
-                            log.info(" [x] Send >>> ***black hole***");
-                        }
+                        sendMessage(session, receivedMessage, mockedRequest, queueNameTo, stringBody, testId, null);
                     }
                 }
             } catch (Exception e) {
@@ -176,6 +155,36 @@ public class IbmMQWorker extends AbstractMqWorker {
         } catch (Exception e) {
             log.error("Caught:", e);
         }
+    }
+
+    private void sendMessage(Session session, Message receivedMessage, MockedRequest mockedRequest, String destinationQueue, String messageBody, String testId, Integer deliveryMode) throws JMSException {
+        if (isNotEmpty(destinationQueue)) {
+            mockedRequest.setDestinationQueue(destinationQueue);
+            mockedRequest.setResponseBody(messageBody);
+
+            Queue destination = session.createQueue(destinationQueue);
+            MessageProducer producer = session.createProducer(destination);
+
+            if (deliveryMode != null) {
+                producer.setDeliveryMode(deliveryMode);
+            }
+
+            Message newMessage = session.createTextMessage(messageBody);
+            copyMessageProperties(receivedMessage, newMessage, testId, destination);
+
+            // Переслать сообщение в очередь-назначение
+            producer.send(newMessage);
+            producer.close();
+            log.info(" [x] Send >>> {} '{}'", destinationQueue, messageBody, StandardCharsets.UTF_8);
+        } else {
+            log.info(" [x] Send >>> ***black hole***");
+        }
+    }
+
+    private String convertTestIdHeaderName(){
+        return testIdHeaderName.contains("-")
+               ? testIdHeaderName.toLowerCase().replace("-", "_HYPHEN_")
+               : testIdHeaderName.toLowerCase().replace("_HYPHEN_", "-") ;
     }
 
     @Override

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/mq/IbmMQWorker.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/mq/IbmMQWorker.java
@@ -79,7 +79,10 @@ public class IbmMQWorker extends AbstractMqWorker {
                     // Wait for a message
                     log.info("Wait messages from {}", queueNameFrom);
                     Message receivedMessage = consumer.receive();
-                    log.info("Received message, JMSMessageID: {}", receivedMessage.getJMSMessageID());
+                    String jmsMessageId = receivedMessage.getJMSMessageID();
+                    String jmsReplyTo = receivedMessage.getJMSReplyTo().toString();
+
+                    log.info("Received message: JMSMessageID={}, JMSReplyTo={}", jmsMessageId, jmsReplyTo);
 
                     MockedRequest mockedRequest = new MockedRequest();
                     //noinspection unchecked
@@ -118,13 +121,17 @@ public class IbmMQWorker extends AbstractMqWorker {
                                 response = stringBody.getBytes();
                             }
 
-                            mockedRequest.setDestinationQueue(mockResponse.getDestinationQueueName());
+                            String destinationQueue = isNotEmpty(mockResponse.getDestinationQueueName())
+                                                      ? mockResponse.getDestinationQueueName()
+                                                      : jmsReplyTo;
 
-                            if (isNotEmpty(mockResponse.getDestinationQueueName())) {
+                            mockedRequest.setDestinationQueue(destinationQueue);
+
+                            if (isNotEmpty(destinationQueue)) {
 
                                 mockedRequest.setResponseBody(new String(response, StandardCharsets.UTF_8));
 
-                                Queue destination = session.createQueue(mockResponse.getDestinationQueueName());
+                                Queue destination = session.createQueue(destinationQueue);
                                 MessageProducer producer = session.createProducer(destination);
                                 producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
 
@@ -135,7 +142,7 @@ public class IbmMQWorker extends AbstractMqWorker {
                                 producer.send(newMessage);
 
                                 producer.close();
-                                log.info(" [x] Send >>> {} '{}'", mockResponse.getDestinationQueueName(), message.getText(), StandardCharsets.UTF_8);
+                                log.info(" [x] Send >>> {} '{}'", destinationQueue, message.getText(), StandardCharsets.UTF_8);
                             }
                         }
                     } else {


### PR DESCRIPTION
Исправлено несколько дефектов:
[[Devops 1178](https://dit.rencredit.ru/jira/browse/DEVOPS-1178)]
Проблема:
Если в Expected Response есть два запроса на один и тот же УРЛ и один из них GET (т.е. пустой), а второй с каким-нибудь телом (POST, например), то получаем исключение Invalid number of mock requests invocations /application/v(\d*)/applications/CRB2019080710304356: expected: 1, actual: 2
Решение:
Добавлена возможность матчить запросы/ответы по пустому телу запроса.

- В выпадающий список Type Matching добавлен вариант absent. Значение поля Matcher при этом не учитывается.
- В зависимостях atf-wiremock версия фреймворка com.github.tomakehurst.wiremock повышена до 2.24.1 (в предыдущей версии опция поиска по пустому значению присутствовала, но не работала должным образом)

Для значения empty поля Type Matching сохранилась прежняя логика - по телу запроса сравнение не происходит.

[[Devops 1184](https://dit.rencredit.ru/jira/browse/DEVOPS-1184)]
Проблема:
Не отлавливаются ответы от mq очереди, в тех случаях, когда для ответа создается временная очередь.

Решение:
- Добавлен этап инициализации MqWorker'ов, в случае, когда типа шага сценария JMS.
- Добавил в IbmMqWorker поддержку байтовых байтовых сообщений.
- Теперь, если в запросе приходит непустой JMSCorrelationID, то он передается в ответ. В противном случае в этот параметр ответа копируется значение JMSMessageId.