### PR TITLE
Глобальные заголовки запросов

### DIFF
--- a/atf-application-ui/src/app/model/project.ts
+++ b/atf-application-ui/src/app/model/project.ts
@@ -27,6 +27,7 @@ export class Project {
   stand: Stand;
   useRandomTestId: boolean;
   testIdHeaderName: string;
+  globalRequestHeaders: string;
   amqpBroker: AmqpBroker;
   groupList: string[];
   environmentVariables: any = {};

--- a/atf-application-ui/src/app/project-settings/project-settings.component.html
+++ b/atf-application-ui/src/app/project-settings/project-settings.component.html
@@ -31,6 +31,7 @@
       <li [class.active]="tab == 'stand'"><a href="#" (click)="selectTab('stand')">{{'Stand' | translate}}</a></li>
       <li [class.active]="tab == 'groupList'"><a href="#" (click)="selectTab('groupList')">{{'Groups' | translate}}</a></li>
       <li [class.active]="tab == 'environmentVariables'"><a href="#" (click)="selectTab('environmentVariables')">{{'Variables' | translate}}</a></li>
+      <li [class.active]="tab == 'globalRequestHeaders'"><a href="#" (click)="selectTab('globalRequestHeaders')">{{'Global headers' | translate}}</a></li>
       <li [class.active]="tab == 'json'"><a href="#" (click)="selectTab('json')">{{'json' | translate}}</a></li>
     </ul>
     <div class="tab-content" style="padding: 10px;">
@@ -152,6 +153,10 @@
             </div>
           </div>
         </div>
+      </div>
+      <div [style.display]="tab == 'globalRequestHeaders' ? '' : 'none'">
+        <label>{{'Global headers' | translate}}:</label>
+        <textarea placeholder="HeaderName: headerValue" rows="5" title="{{'Global request headers' | translate}}" class="form-control" [(ngModel)]="project.globalRequestHeaders"></textarea>
       </div>
       <div [style.display]="tab == 'json' ? '' : 'none'">
         <pre>{{project | json}}</pre>

--- a/atf-application-ui/src/assets/i18n/ru.json
+++ b/atf-application-ui/src/assets/i18n/ru.json
@@ -190,5 +190,7 @@
   "Ignore undeclared requests": "Игнорировать необъявленные запросы",
   "Repeat before each request": "Повторять перед каждым запросом",
   "Variables": "Переменные",
-  "Variable value": "Значение переменной"
+  "Variable value": "Значение переменной",
+  "Global request headers": "Глобальные заголовки запросов",
+  "Global headers": "Глобальные заголовки"
 }

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/ProjectRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/ProjectRo.java
@@ -50,6 +50,8 @@ public class ProjectRo implements AbstractRo {
     private Boolean useRandomTestId;
     @ApiModelProperty("Header name for sending random test ID")
     private String testIdHeaderName;
+    @ApiModelProperty("Global headers which service must send with every project's request")
+    private String globalRequestHeaders;
     @ApiModelProperty("MQ connection parameters")
     private AmqpBrokerRo amqpBroker;
     @ApiModelProperty("List of scenario groups")

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/model/Project.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/model/Project.java
@@ -43,6 +43,7 @@ public class Project implements Serializable, AbstractModel {
     private Stand stand;
     private Boolean useRandomTestId;
     private String testIdHeaderName;
+    private String globalRequestHeaders;
     private AmqpBroker amqpBroker;
     private List<String> groupList;
     private Long mqCheckInterval;
@@ -55,6 +56,7 @@ public class Project implements Serializable, AbstractModel {
         project.setCode(getCode() + "_COPY");
         project.setUseRandomTestId(getUseRandomTestId());
         project.setTestIdHeaderName(getTestIdHeaderName());
+        project.setGlobalRequestHeaders(getGlobalRequestHeaders());
         project.setStand(getStand().copy());
         if (getScenarioList() != null) {
             project.setScenarioList(new LinkedList<>());


### PR DESCRIPTION
[[Devops 1182](https://dit.rencredit.ru/jira/browse/DEVOPS-1182)]
Проблема:
При большом количестве сценариев и шагов тяжело прописать в каждом общие для всех заголовки.

Решение:
В настройки проекта добавлен раздел "Глобальные заголовки" - аналог заголовков шага сценария.
Заголовки транслируются в шаг сценария в момент при старте автотестов. При этом, если в заголовках шага сценария и в глобальных заголовках присутствуют параметры с одинаковыми именами, то параметр сценария считается приоритетным.