### PR TITLE
Возможность сопоставлять запросы и ответы к заглушкам по пустому телу запроса

### DIFF
--- a/atf-application-ui/src/app/mock-service-response/mock-service-response.component.html
+++ b/atf-application-ui/src/app/mock-service-response/mock-service-response.component.html
@@ -64,6 +64,7 @@
         <option [ngValue]="'XPath'">XPath</option>
         <option [ngValue]="'contains'">contains</option>
         <option [ngValue]="'matches'">matches</option>
+        <option [ngValue]="'absent'">absent</option>
       </select>
     </div>
     <div class="col-sm-3" style="margin-top: 10px">

--- a/atf-application-ui/src/app/step-item/step-item.component.html
+++ b/atf-application-ui/src/app/step-item/step-item.component.html
@@ -479,6 +479,7 @@
                         <option [ngValue]="'XPath'">XPath</option>
                         <option [ngValue]="'contains'">contains</option>
                         <option [ngValue]="'matches'">matches</option>
+                        <option [ngValue]="'absent'">absent</option>
                       </select>
                     </div>
 

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/ExpectedServiceRequestRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/ExpectedServiceRequestRo.java
@@ -48,7 +48,7 @@ public class ExpectedServiceRequestRo implements AbstractRo {
     private String ignoredTags;
     @ApiModelProperty("Count of request repetitions")
     private String count;
-    @ApiModelProperty(value = "Type of matching request", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches")
+    @ApiModelProperty(value = "Type of matching request", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches, absent")
     private String typeMatching;
     @ApiModelProperty("Value which will be used to match request. Depends on typeMatching")
     private String pathFilter;

--- a/atf-application/src/main/java/ru/bsc/test/autotester/ro/MockServiceResponseRo.java
+++ b/atf-application/src/main/java/ru/bsc/test/autotester/ro/MockServiceResponseRo.java
@@ -54,7 +54,7 @@ public class MockServiceResponseRo implements AbstractRo {
     private String userName;
     @ApiModelProperty("Password for using basic authentication")
     private String password;
-    @ApiModelProperty(value = "Type of matching response", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches")
+    @ApiModelProperty(value = "Type of matching response", allowableValues = "empty, equalToJson, equalToXml, XPath, contains, matches, absent")
     private String typeMatching;
     @ApiModelProperty("Value which will be used to match response. Depends on typeMatching")
     private String pathFilter;

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/ei/wiremock/model/RequestMatcher.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/ei/wiremock/model/RequestMatcher.java
@@ -41,10 +41,12 @@ public class RequestMatcher {
     public static final String XPATH = "XPath";
     public static final String CONTAINS = "contains";
     public static final String MATCHES = "matches";
+    public static final String ABSENT = "absent";
 
     private String equalToJson;
     private String equalToXml;
     private String matchesXPath;
+    private String absent;
     @JsonRawValue
     private String contains;
     @JsonRawValue
@@ -63,6 +65,8 @@ public class RequestMatcher {
             newRequestMatcher.setMatchesXPath(value);
         } else if (MATCHES.equalsIgnoreCase(type)) {
             newRequestMatcher.setMatches(StringUtils.wrap(value, "\""));
+        } else if (ABSENT.equalsIgnoreCase(type)){
+            newRequestMatcher.setAbsent("absent_pattern");
         }
         return newRequestMatcher;
     }
@@ -71,6 +75,6 @@ public class RequestMatcher {
     public boolean isPresent() {
         return isNotEmpty(equalToJson) || isNotEmpty(equalToXml) ||
                 isNotEmpty(matchesXPath) || isNotEmpty(contains) ||
-                isNotEmpty(matches);
+                isNotEmpty(matches) || isNotEmpty(absent);
     }
 }

--- a/atf-wiremock/pom.xml
+++ b/atf-wiremock/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.22.0</version>
+            <version>2.24.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
[[Devops 1178](https://dit.rencredit.ru/jira/browse/DEVOPS-1178)]
Проблема:
Если в Expected Response есть два запроса на один и тот же УРЛ и один из них GET (т.е. пустой), а второй с каким-нибудь телом (POST, например), то получаем исключение Invalid number of mock requests invocations /application/v(\d*)/applications/CRB2019080710304356: expected: 1, actual: 2
Решение:
Добавлена возможность матчить запросы/ответы по пустому телу запроса.

В выпадающий список Type Matching добавлен вариант absent. Значение поля Matcher при этом не учитывается.
В зависимостях atf-wiremock версия фреймворка com.github.tomakehurst.wiremock повышена до 2.24.1 (в предыдущей версии опция поиска по пустому значению присутствовала, но не работала должным образом)
Для значения empty поля Type Matching сохранилась прежняя логика - по телу запроса сравнение не происходит.