### PR TITLE
Баг с отловом ответов от временной mq очереди

### DIFF
--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/step/executor/MqStepExecutor.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/step/executor/MqStepExecutor.java
@@ -43,6 +43,9 @@ public class MqStepExecutor implements IStepExecutor {
         // 0. Установить ответы сервисов, которые будут использоваться в SoapUI для определения ответа
         ExecutorUtils.setMockResponses(wireMockAdmin, project, testId, step.getMockServiceResponseList(), scenarioVariables);
 
+        // 0.1 Установить ответы для имитации внешних сервисов, работающих через очереди сообщений
+        ExecutorUtils.setMqMockResponses(wireMockAdmin, testId, step.getMqMockResponseList(), scenarioVariables);
+
         // 1. Выполнить запрос БД и сохранить полученные значения
         ExecutorUtils.executeSql(connection, step, scenarioVariables, stepResult);
         stepResult.setSavedParameters(scenarioVariables.toString());

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/exception/UnexpectedMessageTypeException.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/exception/UnexpectedMessageTypeException.java
@@ -1,0 +1,8 @@
+package ru.bsc.test.at.mock.exception;
+
+public class UnexpectedMessageTypeException extends Exception {
+
+    public UnexpectedMessageTypeException(String message) {
+        super(message);
+    }
+}

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/JmsMessageHeadersExtractor.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/JmsMessageHeadersExtractor.java
@@ -17,9 +17,11 @@
 package ru.bsc.test.at.mock.mq;
 
 import org.apache.velocity.context.Context;
+import ru.bsc.test.at.mock.exception.UnexpectedMessageTypeException;
+import ru.bsc.test.at.mock.mq.utils.MessageUtils;
 
 import javax.jms.JMSException;
-import javax.jms.TextMessage;
+import javax.jms.Message;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -35,18 +37,18 @@ public class JmsMessageHeadersExtractor {
     private static final String HEADERS_IN_KEY = "in";
     private static final String HEADERS_OUT_KEY = "out";
 
-    public Map<String, Object> createContext(TextMessage message) throws JMSException {
+    public Map<String, Object> createContext(Message message) throws JMSException, UnexpectedMessageTypeException {
         Map<String, Object> context = new HashMap<>();
         Map<Object, Object> headers = new HashMap<>();
         headers.put(HEADERS_IN_KEY, Collections.unmodifiableMap(getMessageHeaders(message)));
         headers.put(HEADERS_OUT_KEY, new HashMap<>());
         context.put(HEADERS_KEY, headers);
-        context.put(BODY_KEY, message.getText());
+        context.put(BODY_KEY, MessageUtils.extractMessageBody(message));
         return context;
     }
 
     @SuppressWarnings("unchecked")
-    public void setHeadersFromContext(TextMessage message, Context context) throws JMSException {
+    public void setHeadersFromContext(Message message, Context context) throws JMSException {
         Map<String, Object> headers = (Map<String, Object>) context.get(HEADERS_KEY);
         if (headers == null) {
             return;
@@ -60,7 +62,7 @@ public class JmsMessageHeadersExtractor {
         }
     }
 
-    private Map<Object, Object> getMessageHeaders(TextMessage message) throws JMSException {
+    private Map<Object, Object> getMessageHeaders(Message message) throws JMSException {
         Map<Object, Object> headers = new HashMap<>();
         Enumeration names = message.getPropertyNames();
         while (names.hasMoreElements()) {

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/utils/MessageUtils.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/utils/MessageUtils.java
@@ -1,0 +1,35 @@
+package ru.bsc.test.at.mock.mq.utils;
+
+import ru.bsc.test.at.mock.exception.UnexpectedMessageTypeException;
+
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+
+public class MessageUtils {
+
+    private MessageUtils() {
+    }
+
+    public static String extractMessageBody(Message message) throws JMSException, UnexpectedMessageTypeException {
+        if (message instanceof TextMessage) {
+            return extractTextMessageBody((TextMessage) message);
+        } else if (message instanceof BytesMessage) {
+            return extractByteMessageBody((BytesMessage) message);
+        } else {
+            throw new UnexpectedMessageTypeException("Type of Message does not match " + BytesMessage.class.getName() + " or " + TextMessage.class.getName());
+        }
+    }
+
+    public static String extractTextMessageBody(TextMessage message) throws JMSException {
+        return message.getText();
+    }
+
+    public static String extractByteMessageBody(BytesMessage message) throws JMSException {
+        byte[] byteData = new byte[(int) message.getBodyLength()];
+        message.readBytes(byteData);
+        return new String(byteData).replaceAll("<\\?xml(.+?)\\?>", "").trim();
+    }
+
+}

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/worker/AbstractMqWorker.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/worker/AbstractMqWorker.java
@@ -21,13 +21,14 @@ package ru.bsc.test.at.mock.mq.worker;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import ru.bsc.test.at.mock.mq.models.MockMessage;
 import ru.bsc.test.at.mock.mq.predicate.JmsMessagePredicate;
 
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.Queue;
-import javax.jms.TextMessage;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -35,7 +36,7 @@ import java.util.concurrent.TimeoutException;
 @Slf4j
 @Getter
 @RequiredArgsConstructor
-abstract public class AbstractMqWorker implements Runnable, ExceptionListener {
+public abstract class AbstractMqWorker implements Runnable, ExceptionListener {
     private final String queueNameFrom;
     private final String queueNameTo;
     private final List<MockMessage> mockMappingList;
@@ -65,13 +66,15 @@ abstract public class AbstractMqWorker implements Runnable, ExceptionListener {
     }
 
     void copyMessageProperties(
-            TextMessage message,
-            TextMessage newMessage,
+            Message message,
+            Message newMessage,
             String testId,
             Queue destination
     ) throws JMSException {
-        newMessage.setJMSCorrelationID(message.getJMSMessageID());
-        newMessage.setStringProperty(testIdHeaderName, testId);
+        String jmsCorrelationId = message.getJMSCorrelationID();
+        newMessage.setJMSCorrelationID(StringUtils.isNotEmpty(jmsCorrelationId) ? jmsCorrelationId : message.getJMSMessageID());
+
+        newMessage.setStringProperty(getTestIdHeaderName(), testId);
         newMessage.setJMSDestination(destination);
     }
 }


### PR DESCRIPTION
[[Devops 1184](https://dit.rencredit.ru/jira/browse/DEVOPS-1184)]
Проблема:
Не отлавливаются ответы от mq очереди, в тех случаях, когда для ответа создается временная очередь.

Решение:

Добавлен этап инициализации MqWorker'ов, в случае, когда типа шага сценария JMS.
Добавил в IbmMqWorker поддержку байтовых байтовых сообщений.
Теперь, если в запросе приходит непустой JMSCorrelationID, то он передается в ответ. В противном случае в этот параметр ответа копируется значение JMSMessageId.