### PR TITLE
Унификация проверок запросов для MQ и WS

### DIFF
--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/exception/ComparisonException.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/exception/ComparisonException.java
@@ -27,7 +27,7 @@ import org.xmlunit.diff.Diff;
 public class ComparisonException extends RuntimeException {
     public ComparisonException(Diff diff, String expectedRequest, String actualRequest) {
         super(String.format(
-                "Service request error (request differences):%s\n\tExpected: %s\n\tActual: %s\n",
+                "Service request error (request differences):%s%n\tExpected: %s%n\tActual: %s%n",
                 diff,
                 expectedRequest,
                 actualRequest
@@ -36,7 +36,7 @@ public class ComparisonException extends RuntimeException {
 
     public ComparisonException(String diff, String expectedRequest, String actualRequest) {
         super(String.format(
-                "Service request error (request differences):%s\n\tExpected: %s\n\tActual: %s\n",
+                "Service request error (request differences):%s%n\tExpected: %s%n\tActual: %s%n",
                 diff,
                 expectedRequest,
                 actualRequest

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/CompareUtils.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/CompareUtils.java
@@ -1,0 +1,101 @@
+package ru.bsc.test.at.executor.helper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.ElementSelectors;
+import ru.bsc.test.at.executor.exception.ComparisonException;
+import ru.bsc.test.at.executor.exception.JsonParsingException;
+import ru.bsc.test.at.executor.validation.IgnoringComparator;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+public class CompareUtils {
+
+    private static final String IGNORE = "\\u002A" + "ignore" + "\\u002A";
+    private static final String STR_SPLIT = "(\r\n|\n\r|\r|\n|" + IGNORE + ")";
+    private static final String CLEAR_STR_PATTERN = "(\r\n|\n\r|\r|\n)";
+    private static final String NBS_PATTERN = "[\\s\\u00A0]";
+
+    private CompareUtils() {
+    }
+
+    static ComparisonResult compareRequestAsXml(String expectedRequestBody, String actualRequestBody, Set<String> ignoredTags) {
+        Diff diff = DiffBuilder.compare(StringUtils.defaultString(expectedRequestBody))
+                               .withTest(StringUtils.defaultString(actualRequestBody))
+                               .checkForIdentical()
+                               .ignoreComments()
+                               .ignoreWhitespace()
+                               .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+                               .withDifferenceEvaluator(new IgnoreTagsDifferenceEvaluator(ignoredTags))
+                               .build();
+
+        return new ComparisonResult(diff.hasDifferences(), diff.toString(), expectedRequestBody, actualRequestBody);
+    }
+
+    static ComparisonResult compareRequestAsJson(String expectedRequestBody, String actualBody, Set<String> ignoringPaths, String mode) {
+        String defaultExpectedRequestBody = StringUtils.defaultString(expectedRequestBody);
+        String defaultActualBody = StringUtils.defaultString(actualBody);
+        ObjectMapper om = new ObjectMapper();
+        try {
+            om.readValue(defaultExpectedRequestBody, Object.class);
+            om.readValue(defaultActualBody, Object.class);
+        } catch (Exception e) {
+            throw new JsonParsingException(e);
+        }
+
+        ComparisonResult comparisonResult;
+        try {
+            List<Customization> customizations = ignoringPaths.stream()
+                                                              .map(p -> new Customization(p, (o1, o2) -> true))
+                                                              .collect(Collectors.toList());
+
+            JSONCompareMode compareMode = StringUtils.isEmpty(mode) ? JSONCompareMode.STRICT : JSONCompareMode.valueOf(mode);
+            JSONAssert.assertEquals(defaultExpectedRequestBody.replaceAll("\\s", " "),
+                    defaultActualBody.replaceAll("\\s", " "),
+                    new IgnoringComparator(compareMode, customizations));
+
+            comparisonResult = new ComparisonResult(false, "", expectedRequestBody, actualBody);
+        }catch (Throwable assertionError){
+            comparisonResult = new ComparisonResult(true, assertionError.getMessage(), expectedRequestBody, actualBody);
+        }
+
+        return comparisonResult;
+    }
+
+    static ComparisonResult compareRequestAsString(String expectedRequest, String actualRequest) {
+        String defaultExpectedRequest = StringUtils.defaultString(expectedRequest);
+        String defaultActualRequest = StringUtils.defaultString(actualRequest);
+
+        String[] split = defaultExpectedRequest.split(STR_SPLIT);
+        defaultActualRequest = defaultActualRequest.replaceAll(CLEAR_STR_PATTERN, "").replaceAll(NBS_PATTERN, " ");
+
+        if (split.length == 1 && !Objects.equals(defaultIfNull(split[0], ""), defaultIfNull(defaultActualRequest, ""))) {
+            throw new ComparisonException("", defaultExpectedRequest, defaultActualRequest);
+        }
+
+        int i = 0;
+        boolean notEquals = false;
+        StringBuilder diff = new StringBuilder("\n");
+        for (String s : split) {
+            i = defaultActualRequest.indexOf(s.trim(), i);
+            if (i < 0) {
+                notEquals = true;
+                diff.append(s.trim()).append("\n");
+            }
+        }
+
+        return new ComparisonResult(notEquals, diff.toString(), expectedRequest, actualRequest);
+    }
+
+}

--- a/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/ComparisonResult.java
+++ b/atf-executor/src/main/java/ru/bsc/test/at/executor/helper/ComparisonResult.java
@@ -6,14 +6,10 @@ import org.xmlunit.diff.Diff;
 
 @AllArgsConstructor
 @Getter
-public class MqComparisonResult {
+public class ComparisonResult {
 
-    private Diff diff;
+    private boolean hasDifferences;
+    private String diff;
     private String expectedRequestBody;
     private String actualRequestBody;
-
-    public boolean hasDifferences(){
-        return diff.hasDifferences();
-    }
-
 }

--- a/atf-wiremock/pom.xml
+++ b/atf-wiremock/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>concurrent-junit</artifactId>
             <version>1.0.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsJsonMessagePredicate.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsJsonMessagePredicate.java
@@ -1,0 +1,56 @@
+/*
+ * AuTe Framework project
+ * Copyright 2018 BSC Msc, LLC
+ *
+ * ATF project is licensed under
+ *     The Apache 2.0 License
+ *     http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * For more information visit http://www.bsc-ideas.com/ru/
+ *
+ * Files ru.bsc.test.autotester.diff.DiffMatchPatch.java, ru.bsc.test.autotester.diff.Diff.java,
+ * ru.bsc.test.autotester.diff.LinesToCharsResult, ru.bsc.test.autotester.diff.Operation,
+ * ru.bsc.test.autotester.diff.Patch
+ * are copied from https://github.com/google/diff-match-patch
+ */
+
+package ru.bsc.test.at.mock.mq.predicate;
+
+import com.jayway.jsonpath.DocumentContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import ru.bsc.test.at.mock.mq.models.MockMessage;
+
+import java.util.List;
+
+@Slf4j
+public class JmsJsonMessagePredicate extends JmsMessagePredicate {
+
+    private final DocumentContext messageBody;
+
+    public JmsJsonMessagePredicate(String source, String testId, DocumentContext body) {
+        super(source, testId);
+        this.messageBody = body;
+    }
+
+    @Override
+    public boolean test(MockMessage message) {
+        return super.test(message) && testJsonPath(message);
+    }
+
+    private boolean testJsonPath(MockMessage message) {
+        if (StringUtils.isEmpty(message.getXpath())) {
+            return true;
+        }
+
+        Object result = messageBody.read(message.getXpath());
+        if (result == null){
+            return false;
+        } else if (result instanceof List){
+            List<?> resultList = (List<?>) result;
+            return !resultList.isEmpty();
+        }
+
+        return true;
+    }
+}

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsMessagePredicate.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsMessagePredicate.java
@@ -18,19 +18,8 @@ package ru.bsc.test.at.mock.mq.predicate;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 import ru.bsc.test.at.mock.mq.models.MockMessage;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.Objects;
 import java.util.function.Predicate;
 
@@ -41,18 +30,16 @@ import java.util.function.Predicate;
 @Slf4j
 public class JmsMessagePredicate implements Predicate<MockMessage> {
     private final String source;
-    private final Document messageBody;
     private final String testId;
 
-    public JmsMessagePredicate(String source, String body, String testId) {
+    public JmsMessagePredicate(String source, String testId) {
         this.source = source;
-        this.messageBody = parseXml(body);
         this.testId = testId;
     }
 
     @Override
     public boolean test(MockMessage message) {
-        return testSourceName(message) && testTestId(message) && testXpath(message);
+        return testSourceName(message) && testTestId(message);
     }
 
     private boolean testSourceName(MockMessage message) {
@@ -63,30 +50,4 @@ public class JmsMessagePredicate implements Predicate<MockMessage> {
         return Objects.equals(testId, message.getTestId()) || StringUtils.isEmpty(message.getTestId());
     }
 
-    private boolean testXpath(MockMessage message) {
-        if (StringUtils.isEmpty(message.getXpath())) {
-            return true;
-        }
-        try {
-            return null != XPathFactory.newInstance().newXPath().evaluate(
-                    message.getXpath(),
-                    messageBody,
-                    XPathConstants.NODE
-            );
-        } catch (XPathExpressionException e) {
-            log.warn("XPath problem: {}", e.getMessage());
-            return false;
-        }
-    }
-
-    private Document parseXml(String stringBody) {
-        try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            DocumentBuilder db = dbf.newDocumentBuilder();
-            return db.parse(new InputSource(new StringReader(stringBody)));
-        } catch (IOException | ParserConfigurationException | SAXException e) {
-            log.info("Cannot parse XML document: {}", e.getMessage());
-            return null;
-        }
-    }
 }

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsMessagePredicateFactory.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsMessagePredicateFactory.java
@@ -1,0 +1,72 @@
+package ru.bsc.test.at.mock.mq.predicate;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.JsonPath;
+import lombok.extern.slf4j.Slf4j;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.StringReader;
+
+@Slf4j
+public class JmsMessagePredicateFactory {
+
+    private static JmsMessagePredicateFactory factory;
+
+    private JmsMessagePredicateFactory() {
+    }
+
+    public static JmsMessagePredicateFactory getInstance(){
+        if (factory == null){
+            factory = new JmsMessagePredicateFactory();
+        }
+
+        return factory;
+    }
+
+    public JmsMessagePredicate newJmsMessagePredicate(String source, String testId, String messageBody){
+        Document xmlDocument = parseXml(messageBody);
+        if (xmlDocument != null) {
+            return new JmsXmlMessagePredicate(source, testId, xmlDocument);
+        }
+
+        DocumentContext jsonContext = parseJson(messageBody);
+        if (jsonContext != null){
+            return new JmsJsonMessagePredicate(source, testId, jsonContext);
+        }
+
+        return new JmsMessagePredicate(source, testId);
+    }
+
+    private DocumentContext parseJson(String json){
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.readValue(json, Object.class);
+            return JsonPath.parse(json);
+        }catch (IOException e){
+            log.debug("Cannot parse JSON: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private Document parseXml(String stringBody) {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            return db.parse(new InputSource(new StringReader(stringBody)));
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            log.debug("Cannot parse XML document: {}", e.getMessage());
+            return null;
+        }
+    }
+
+}

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsXmlMessagePredicate.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/predicate/JmsXmlMessagePredicate.java
@@ -1,0 +1,61 @@
+/*
+ * AuTe Framework project
+ * Copyright 2018 BSC Msc, LLC
+ *
+ * ATF project is licensed under
+ *     The Apache 2.0 License
+ *     http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * For more information visit http://www.bsc-ideas.com/ru/
+ *
+ * Files ru.bsc.test.autotester.diff.DiffMatchPatch.java, ru.bsc.test.autotester.diff.Diff.java,
+ * ru.bsc.test.autotester.diff.LinesToCharsResult, ru.bsc.test.autotester.diff.Operation,
+ * ru.bsc.test.autotester.diff.Patch
+ * are copied from https://github.com/google/diff-match-patch
+ */
+
+package ru.bsc.test.at.mock.mq.predicate;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.Document;
+import ru.bsc.test.at.mock.mq.models.MockMessage;
+
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+/**
+ * Created by smakarov
+ * 17.07.2019 11:04
+ */
+@Slf4j
+public class JmsXmlMessagePredicate extends JmsMessagePredicate {
+    private final Document messageBody;
+
+    public JmsXmlMessagePredicate(String source, String testId, Document body) {
+        super(source, testId);
+        this.messageBody = body;
+    }
+
+    @Override
+    public boolean test(MockMessage message) {
+        return super.test(message) && testXpath(message);
+    }
+
+    private boolean testXpath(MockMessage message) {
+        if (StringUtils.isEmpty(message.getXpath())) {
+            return true;
+        }
+        try {
+            return null != XPathFactory.newInstance().newXPath().evaluate(
+                    message.getXpath(),
+                    messageBody,
+                    XPathConstants.NODE
+            );
+        } catch (XPathExpressionException e) {
+            log.warn("XPath problem: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/worker/AbstractMqWorker.java
+++ b/atf-wiremock/src/main/java/ru/bsc/test/at/mock/mq/worker/AbstractMqWorker.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import ru.bsc.test.at.mock.mq.models.MockMessage;
 import ru.bsc.test.at.mock.mq.predicate.JmsMessagePredicate;
+import ru.bsc.test.at.mock.mq.predicate.JmsMessagePredicateFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -55,7 +56,7 @@ public abstract class AbstractMqWorker implements Runnable, ExceptionListener {
 
     MockMessage findMockMessage(String testId, String stringBody) {
         synchronized (mockMappingList) {
-            final JmsMessagePredicate jmsMessageFilter = new JmsMessagePredicate(queueNameFrom, stringBody, testId);
+            final JmsMessagePredicate jmsMessageFilter = JmsMessagePredicateFactory.getInstance().newJmsMessagePredicate(queueNameFrom, testId, stringBody);
             return mockMappingList
                     .stream()
                     .sorted()


### PR DESCRIPTION
[DEVOPS-1362](https://dit.rencredit.ru/jira/browse/DEVOPS-1362)
1. По аналогии с проверкой на соответствие запроса ожидаемому сделал проверку для Jms сообщений и переложил всё это в отдельный CompareUtils класс, чтобы избежать дублирования

2. Для Wiremock создал несколько JmsMessagePredicate, поддерживающие json, Xml и просто String.